### PR TITLE
add is alive

### DIFF
--- a/wrapper.py
+++ b/wrapper.py
@@ -129,7 +129,7 @@ def is_alive():
         json_response["error"] = "index_not_found"
         json_response["query_index"] = find_string
 
-    return json_response
+    return jsonify(json_response)
 
 @app.route('/get_trx')
 def get_trx():

--- a/wrapper.py
+++ b/wrapper.py
@@ -2,7 +2,7 @@ from flask import Flask
 from flask import jsonify
 from flask import request
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, query, Q, DocType, utils
 from elasticsearch_dsl.exceptions import IllegalOperation
@@ -90,6 +90,46 @@ def get_single_operation():
         results.append(hit.to_dict())
 
     return jsonify(results)
+
+@app.route('/is_alive')
+def is_alive():
+    find_string = datetime.utcnow().strftime("%Y-%m")
+    from_date = (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
+
+    s = Search(using=es, index="bitshares-" + find_string)
+    s.query = Q("range", block_data__block_time={'gte': from_date, 'lte': "now"})
+    s.aggs.metric("max_block_time", "max", field="block_data.block_time")
+
+    json_response = {
+        "server_time": datetime.utcnow(),
+        "head_block_timestamp": None,
+        "head_block_time": None
+    }
+
+    try:
+        response = s.execute()
+        if response.aggregations.max_block_time.value is not None:
+            json_response["head_block_time"] = str(response.aggregations.max_block_time.value_as_string)
+            json_response["head_block_timestamp"] = response.aggregations.max_block_time.value
+            json_response["deltatime"] = abs((datetime.utcfromtimestamp(json_response["head_block_timestamp"] / 1000) - json_response["server_time"]).total_seconds())
+            if json_response["deltatime"] < 30:
+                json_response["status"] = "ok"
+            else:
+                json_response["status"] = "out_of_sync"
+                json_response["error"] = "last_block_too_old"
+        else:
+            json_response["status"] = "out_of_sync"
+            json_response["deltatime"] = "Infinite"
+            json_response["query_index"] = find_string
+            json_response["query_from_date"] = from_date
+            json_response["error"] = "no_blocks_last_24_hours"
+    except NotFoundError:
+        json_response["status"] = "out_of_sync"
+        json_response["deltatime"] = "Infinite"
+        json_response["error"] = "index_not_found"
+        json_response["query_index"] = find_string
+
+    return json_response
 
 @app.route('/get_trx')
 def get_trx():

--- a/wrapper.yaml
+++ b/wrapper.yaml
@@ -86,6 +86,20 @@ paths:
       tags:
         - wrapper
 
+  "/is_alive":
+    get:
+      description: Queries the latest head block and gives synchronization status of the elastic search database. As long as status is ok, nothing to worry
+      operationId: is_alive
+      produces:
+        - application/json
+      responses:
+        200:
+          description: json data with status, server_time and head_block_time and statistics
+        500:
+          description: Error processing parameters
+      tags:
+        - wrapper
+
   "/get_single_operation":
     get:
       description: Get a single operation by the operation ID.
@@ -110,6 +124,7 @@ paths:
         - https
       tags:
         - wrapper
+
   "/get_trx":
     get:
       description: Get the operations inside a transaction hash.


### PR DESCRIPTION
This is a sibling PR to https://github.com/oxarbitrage/bitshares-explorer-api/pull/40

I quite like the option to just run a ES wrapper, because we are running ES but not explorer on top.
Are there any chances we could have this repository be actively maintained as independent one from explorer api? @oxarbitrage 

Adds a json response that queries last head block, output is as below
```
{
  "deltatime": 0.52071,
  "head_block_time": "2019-01-24T11:16:57.000Z",
  "head_block_timestamp": 1548328617000.0,
  "server_time": "2019-01-24T11:16:57.520710Z",
  "status": "ok"
}
```

Possible `status` values are `ok` and `out_of_sync`, and in the latter a `error` indicator is added to the json. If ES is not reachable, a 500 is returned.

Signed-off-by: Stefan Schiessl <stefan.schiessl@blockchainprojectsbv.com>